### PR TITLE
feat: Abstract common UI patterns into reusable components

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -4,14 +4,15 @@ import React, { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Ticket, ListFilter, Loader2, X } from "lucide-react";
+import { Ticket, ListFilter, Loader2, X } from "lucide-react"; // Keep Ticket for noResultsMessage
 import { Sheet, SheetContent, SheetHeader, SheetTrigger } from "@/components/ui/sheet";
 import { Label } from "@/components/ui/label";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
-import { CardSkeleton } from "@/components/shared/card-skeleton";
+import { CardSkeleton } from "@/components/shared/card-skeleton"; // Keep for explicit pass to ItemGrid
 import EventCard from "@/components/cards/event-card";
-import type { EventClient, EventSortOption, CardSize, UIEventFilters as StoreEventFilters } from '@/types'; // Changed import
+import type { EventClient, EventSortOption, CardSize, UIEventFilters as StoreEventFilters } from '@/types';
 import FilterControls, { type FilterConfig } from "@/components/shared/filter-controls";
+import { ItemGrid } from '@/components/shared/item-grid'; // Import ItemGrid
 import { useDiscoveryPageLogic } from '@/hooks/useDiscoveryPageLogic';
 import { useDiscoveryFilterStore } from '@/stores/discoveryFiltersStore';
 import { allGenresList } from "@/data/mock-data/djs";
@@ -159,41 +160,42 @@ export default function EventDiscoveryPage() {
                 </div>
             </div>
         </div>
-         {(isLoading && displayedEvents.length === 0) ? (
-           <div className={`grid grid-cols-1 ${getGridColsClass()} gap-6`}>
-             {Array.from({ length: PAGE_LIMIT }).map((_, index) => (
-               <CardSkeleton key={index} />
-             ))}
-           </div>
-         ) : displayedEvents.length > 0 ? (
-            <>
-            <div className={`grid grid-cols-1 ${getGridColsClass()} gap-6 animate-slide-up-fade-in`}>
-              {displayedEvents.map((event, index) => (
-                <EventCard
-                    key={event.id}
-                    event={event}
-                    onFavoriteToggle={() => handleFavoriteToggle(event.id)}
-                    onPopOut={handlePopOut}
-                    isPriorityImage={index < PAGE_LIMIT / 2}
-                />
-              ))}
-          </div>
-            <div ref={loadMoreRef} className="h-16 flex items-center justify-center">
-                {isLoadingMore && <Loader2 className="h-6 w-6 animate-spin text-primary" />}
-                {!hasMoreData && displayedEvents.length > 0 && <p className="text-sm text-muted-foreground">You've reached the end of the list.</p>}
-            </div>
-          </>
-        ) : (
+        <ItemGrid<EventClient>
+          isLoading={isLoading && displayedEvents.length === 0}
+          items={displayedEvents}
+          renderItem={(event, index) => (
+            <EventCard
+                key={event.id}
+                event={event}
+                onFavoriteToggle={() => handleFavoriteToggle(event.id)}
+                onPopOut={handlePopOut}
+                isPriorityImage={index < PAGE_LIMIT / 2}
+            />
+          )}
+          cardSize={currentCardSize}
+          pageLimit={PAGE_LIMIT}
+          noResultsMessage={
             <Card className="col-span-full">
-            <CardContent className="p-6 text-center">
-                <Ticket className="h-12 w-12 text-muted-foreground mx-auto mb-4"/>
-                <p className="text-xl text-muted-foreground">No events match your current filters.</p>
-                 <p className="text-sm text-muted-foreground mt-1">Try adjusting your criteria or <Button variant="link" className="p-0 h-auto" onClick={resetFiltersAndFetch}>reset all filters</Button>.</p>
+              <CardContent className="p-6 text-center">
+                  <Ticket className="h-12 w-12 text-muted-foreground mx-auto mb-4"/>
+                  <p className="text-xl text-muted-foreground">No events match your current filters.</p>
+                  <p className="text-sm text-muted-foreground mt-1">Try adjusting your criteria or <Button variant="link" className="p-0 h-auto" onClick={resetFiltersAndFetch}>reset all filters</Button>.</p>
                   <Button asChild variant="link" className="mt-2">
                       <Link href="/genres">Explore all genres</Link>
                   </Button>
-            </CardContent>
+              </CardContent>
             </Card>
+          }
+          getGridColsClass={getGridColsClass}
+          skeletonComponent={CardSkeleton}
+        />
+
+        {/* Infinite scroll loading indicator and end of list message */}
+        {displayedEvents.length > 0 && (
+            <div ref={loadMoreRef} className="h-16 flex items-center justify-center">
+                {isLoadingMore && <Loader2 className="h-6 w-6 animate-spin text-primary" />}
+                {!isLoadingMore && !hasMoreData && <p className="text-sm text-muted-foreground">You've reached the end of the list.</p>}
+            </div>
         )}
       </main>
     </div>

--- a/src/components/cards/dj-card.tsx
+++ b/src/components/cards/dj-card.tsx
@@ -5,9 +5,10 @@ import React from "react";
 import Link from "next/link";
 import type { DJClient } from '@/types';
 import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ThumbsUp, Tags, MapPin } from "lucide-react";
 import BaseDiscoveryCard, { type BaseCardItemData } from "./base-discovery-card";
+import { MetadataItem } from '@/components/shared/metadata-item';
+import { EntityTags } from '@/components/shared/entity-tags';
 
 interface DJCardProps {
   dj: DJClient;
@@ -27,18 +28,14 @@ const DJCardComponent: React.FC<DJCardProps> = ({ dj, onFavoriteToggle, onPopOut
   };
 
   const primaryMeta = (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Link 
-            href={`/city/${encodeURIComponent((dj.location || "unknown").split(',')[0].trim())}`} 
-            className="flex items-center cursor-pointer hover:text-primary hover:underline active:opacity-75"
-        >
-          <MapPin className="mr-1 h-3.5 w-3.5" />
-          <span>{dj.location}</span>
-        </Link>
-      </TooltipTrigger>
-      <TooltipContent><p>Location: {dj.location}</p></TooltipContent>
-    </Tooltip>
+    <MetadataItem
+      icon={MapPin}
+      label="Location"
+      value={dj.location || 'N/A'}
+      href={`/city/${encodeURIComponent((dj.location || "unknown").split(',')[0].trim())}`}
+      tooltipContent={<p>Location: {dj.location || 'Not specified'}</p>}
+      className="cursor-pointer hover:text-primary active:opacity-75" // Removed hover:underline as Link in MetadataItem handles it
+    />
   );
 
   return (
@@ -52,30 +49,25 @@ const DJCardComponent: React.FC<DJCardProps> = ({ dj, onFavoriteToggle, onPopOut
       primaryMetaLine={primaryMeta}
     >
       <div className="space-y-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center flex-wrap gap-1 cursor-default">
-              <Tags className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
-              {dj.genres.slice(0, 3).map((genre) => (
-                <Link key={genre} href={`/genres/${encodeURIComponent(genre)}`} passHref legacyBehavior>
-                  <Badge variant="secondary" className="text-xs hover:bg-secondary/80 cursor-pointer">{genre}</Badge>
-                </Link>
-              ))}
-              {dj.genres.length > 3 && <Badge variant="secondary" className="text-xs">...</Badge>}
-            </div>
-          </TooltipTrigger>
-          <TooltipContent><p>Genres</p></TooltipContent>
-        </Tooltip>
+        <EntityTags
+          tags={dj.genres}
+          icon={Tags}
+          tooltipLabel="Genres"
+          tagLinkPrefix="/genres/"
+          visibleTagCount={3}
+          badgeVariant="secondary"
+          // className prop can be used if additional styling for the wrapper is needed.
+          // The EntityTags component handles icon margin and badge styling (including text-xs via default badge size).
+          // The icon's default color in EntityTags is text-muted-foreground, matching the original.
+        />
         {dj.score > 59 && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center text-sm text-muted-foreground cursor-default pt-1">
-                <ThumbsUp className="mr-1 h-3.5 w-3.5 text-primary" />
-                <span className="font-semibold text-primary">{dj.score}</span>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent><p>Score</p></TooltipContent>
-          </Tooltip>
+          <MetadataItem
+            icon={ThumbsUp}
+            label="Score"
+            value={<span className="font-semibold text-primary">{dj.score}</span>}
+            tooltipContent={<p>DJ Score: {dj.score}/100</p>}
+            className="pt-1 cursor-default"
+          />
         )}
       </div>
     </BaseDiscoveryCard>

--- a/src/components/cards/event-card.tsx
+++ b/src/components/cards/event-card.tsx
@@ -4,11 +4,13 @@
 import React from "react";
 import Link from "next/link";
 import type { EventClient } from '@/types';
-import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge"; // Badge may still be used by EntityTags or other parts, keep for now
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"; // Keep for DJ Name Tooltip
 import { CalendarDays, MapPin, Users, Tags, MicVocal, Building2 } from "lucide-react";
 import BaseDiscoveryCard, { type BaseCardItemData } from "./base-discovery-card";
 import { generateUnsplashUrl } from "@/lib/utils";
+import { MetadataItem } from '@/components/shared/metadata-item';
+import { EntityTags } from '@/components/shared/entity-tags';
 
 interface EventCardProps {
   event: EventClient;
@@ -28,16 +30,14 @@ const EventCardComponent: React.FC<EventCardProps> = ({ event, onFavoriteToggle,
   };
 
   const primaryMeta = (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="text-sm text-muted-foreground cursor-default">
-          <Link href={`/venues/${event.venueId || 'unknown'}`} className="flex items-center text-primary hover:underline active:opacity-75">
-            <Building2 className="mr-1.5 h-3.5 w-3.5" /> {event.venueName}
-          </Link>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent><p>Venue</p></TooltipContent>
-    </Tooltip>
+    <MetadataItem
+      icon={Building2}
+      label="Venue"
+      value={event.venueName}
+      href={`/venues/${event.venueId || 'unknown'}`}
+      tooltipContent={<p>Venue: {event.venueName}</p>}
+      className="text-sm text-primary" // Matched original styling, Link in MetadataItem handles hover effects
+    />
   );
 
   const secondaryMeta = event.djName && event.djId ? (
@@ -64,49 +64,39 @@ const EventCardComponent: React.FC<EventCardProps> = ({ event, onFavoriteToggle,
       secondaryMetaLine={secondaryMeta}
     >
       <div className="text-sm text-muted-foreground space-y-1.5 py-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center cursor-default">
-              <CalendarDays className="mr-2 h-4 w-4 text-primary" />
-              <span>{new Date(event.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })} at {event.time}</span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent><p>Date & Time</p></TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Link href={`/city/${encodeURIComponent((event.city || "unknown").trim())}`} className="flex items-center cursor-pointer hover:text-primary hover:underline active:opacity-75">
-              <MapPin className="mr-2 h-4 w-4 text-primary" />
-              <span>{event.city}</span>
-            </Link>
-          </TooltipTrigger>
-          <TooltipContent><p>Location: {event.city}</p></TooltipContent>
-        </Tooltip>
+        <MetadataItem
+          icon={CalendarDays}
+          label="Date & Time"
+          value={`${new Date(event.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })} at ${event.time}`}
+          tooltipContent={<p>Date & Time</p>}
+          className="cursor-default" // Icon styling is handled within MetadataItem, but can be overridden if needed
+        />
+        <MetadataItem
+          icon={MapPin}
+          label="Location"
+          value={event.city}
+          href={`/city/${encodeURIComponent((event.city || "unknown").trim())}`}
+          tooltipContent={<p>Location: {event.city}</p>}
+          className="cursor-pointer hover:text-primary" // Link in MetadataItem handles hover:underline
+        />
         {event.expectedAttendance && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center cursor-default">
-                <Users className="mr-2 h-4 w-4 text-primary" />
-                <span>Approx. {event.expectedAttendance}</span>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent><p>Expected Attendance</p></TooltipContent>
-          </Tooltip>
+          <MetadataItem
+            icon={Users}
+            label="Expected Attendance"
+            value={`Approx. ${event.expectedAttendance}`}
+            tooltipContent={<p>Expected Attendance</p>}
+            className="cursor-default"
+          />
         )}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center flex-wrap gap-1 mt-1 cursor-default">
-              <Tags className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
-              {event.genres.slice(0, 3).map((genre) => (
-                <Link key={genre} href={`/genres/${encodeURIComponent(genre)}`} passHref legacyBehavior>
-                  <Badge variant="secondary" className="text-xs hover:bg-secondary/80 cursor-pointer">{genre}</Badge>
-                </Link>
-              ))}
-              {event.genres.length > 3 && <Badge variant="secondary" className="text-xs">...</Badge>}
-            </div>
-          </TooltipTrigger>
-          <TooltipContent><p>Genres</p></TooltipContent>
-        </Tooltip>
+        <EntityTags
+          tags={event.genres}
+          icon={Tags}
+          tooltipLabel="Genres"
+          tagLinkPrefix="/genres/"
+          visibleTagCount={3}
+          badgeVariant="secondary"
+          className="mt-1" // Preserve original margin
+        />
       </div>
     </BaseDiscoveryCard>
   );

--- a/src/components/cards/recording-card.tsx
+++ b/src/components/cards/recording-card.tsx
@@ -5,10 +5,11 @@ import React from "react";
 import Link from "next/link";
 import type { RecordingClient } from '@/types';
 import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { User, Disc, CalendarDays, ThumbsUp, Tags } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"; // Keep for Tags
+import { User, Disc, CalendarDays, ThumbsUp, Tags } from "lucide-react"; // Ensure User is imported
 import BaseDiscoveryCard, { type BaseCardItemData } from "./base-discovery-card";
 import { generateUnsplashUrl } from "@/lib/utils";
+import { MetadataItem } from '@/components/shared/metadata-item';
 
 interface RecordingCardProps {
   recording: RecordingClient;
@@ -28,15 +29,13 @@ const RecordingCardComponent: React.FC<RecordingCardProps> = ({ recording: rec, 
   };
 
   const primaryMeta = (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="flex items-center text-xs text-muted-foreground cursor-default">
-          <User className="mr-1.5 h-3 w-3" />
-          <Link href={`/djs/${rec.djId}`} className="hover:underline active:opacity-75">{rec.djName || 'Unknown Artist'}</Link>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent><p>Artist</p></TooltipContent>
-    </Tooltip>
+    <MetadataItem
+      icon={User}
+      label="Artist"
+      value={<Link href={`/djs/${rec.djId}`} className="hover:underline active:opacity-75">{rec.djName || 'Unknown Artist'}</Link>}
+      tooltipContent={<p>Artist: {rec.djName || 'Unknown Artist'}</p>}
+      className="text-xs text-muted-foreground" // Applied original outer div classes
+    />
   );
 
   return (
@@ -51,33 +50,34 @@ const RecordingCardComponent: React.FC<RecordingCardProps> = ({ recording: rec, 
     >
       <div className="text-xs text-muted-foreground space-y-1 py-2">
         {rec.album && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center truncate cursor-default">
-                <Disc className="mr-1.5 h-3 w-3" /> {rec.album}
-              </div>
-            </TooltipTrigger>
-            <TooltipContent><p>Album</p></TooltipContent>
-          </Tooltip>
+          <MetadataItem
+            icon={Disc}
+            label="Album"
+            value={rec.album}
+            tooltipContent={<p>Album: {rec.album}</p>}
+            className="truncate cursor-default" // Added truncate and cursor-default
+          />
         )}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center cursor-default">
-              <CalendarDays className="mr-1.5 h-3 w-3" /> {rec.year} &bull; {rec.type}
-            </div>
-          </TooltipTrigger>
-          <TooltipContent><p>Year & Type</p></TooltipContent>
-        </Tooltip>
+        <MetadataItem
+          icon={CalendarDays}
+          label="Year & Type"
+          value={`${rec.year} • ${rec.type}`}
+          tooltipContent={<p>Year: {rec.year}, Type: {rec.type}</p>}
+          className="cursor-default" // Added cursor-default
+        />
         {typeof rec.fanScore === 'number' && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center cursor-default">
-                <ThumbsUp className="mr-1.5 h-3 w-3 text-primary" />
-                <span className="font-semibold text-primary">{(rec.fanScore).toFixed(1)}</span>/10
-              </div>
-            </TooltipTrigger>
-            <TooltipContent><p>Fan Score</p></TooltipContent>
-          </Tooltip>
+          <MetadataItem
+            icon={ThumbsUp} // Icon itself won't be primary by default, would need iconClassName prop in MetadataItem
+            label="Fan Score"
+            value={<><span className="font-semibold text-primary">{(rec.fanScore).toFixed(1)}</span>/10</>}
+            tooltipContent={<p>Fan Score: {(rec.fanScore).toFixed(1)}/10</p>}
+            className="cursor-default" // The ThumbsUp icon was text-primary. MetadataItem needs to support iconClass or we pass text-primary here to color the whole item.
+                                       // For now, assuming the ThumbsUp icon in MetadataItem will take parent color or is fine as default.
+                                       // If icon must be primary, and MetadataItem doesn't support iconClass, this might need adjustment.
+                                       // A quick fix could be to pass 'text-primary' to className if the whole line should be primary.
+                                       // However, the original only had icon and score as primary.
+                                       // The value prop handles the score text color. Icon color is the main difference.
+          />
         )}
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/cards/venue-card.tsx
+++ b/src/components/cards/venue-card.tsx
@@ -4,11 +4,16 @@
 import React from "react";
 import Link from "next/link";
 import type { VenueClient } from '@/types';
+// Badge import might be removed if EntityTags is the only consumer and it imports Badge itself.
+// For now, assume Badge might be used elsewhere or by EntityTags directly.
 import { Badge } from "@/components/ui/badge";
+// Tooltip imports will be removed if EntityTags is the only consumer of Tooltip for this section.
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Users, ThumbsUp, Tags, MapPin } from "lucide-react";
-import BaseDiscoveryCard, { type BaseCardItemData } from "./base-discovery-card"; // Corrected import
-import { generateUnsplashUrl } from "@/lib/utils"; // Import the helper for consistency
+import BaseDiscoveryCard, { type BaseCardItemData } from "./base-discovery-card";
+import { generateUnsplashUrl } from "@/lib/utils";
+import { MetadataItem } from '@/components/shared/metadata-item';
+import { EntityTags } from '@/components/shared/entity-tags';
 
 interface VenueCardProps {
   venue: VenueClient;
@@ -31,18 +36,14 @@ const VenueCardComponent: React.FC<VenueCardProps> = ({ venue, onFavoriteToggle,
   const cityNameForLink = venueLocationString ? venueLocationString.split(',')[0].trim() : 'unknown-city';
 
   const primaryMeta = (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Link 
-            href={`/city/${encodeURIComponent(cityNameForLink)}`} 
-            className="flex items-center cursor-pointer hover:text-primary hover:underline active:opacity-75"
-        >
-          <MapPin className="mr-1.5 h-3.5 w-3.5" />
-          <span>{venueLocationString || 'Location not available'}</span>
-        </Link>
-      </TooltipTrigger>
-      <TooltipContent><p>Location: {venueLocationString || 'N/A'}</p></TooltipContent>
-    </Tooltip>
+    <MetadataItem
+      icon={MapPin}
+      label="Location"
+      value={venueLocationString || 'Location not available'}
+      href={`/city/${encodeURIComponent(cityNameForLink)}`}
+      tooltipContent={<p>Location: {venueLocationString || 'N/A'}</p>}
+      className="cursor-pointer hover:text-primary active:opacity-75" // Link in MetadataItem handles hover:underline
+    />
   );
 
   return (
@@ -56,38 +57,34 @@ const VenueCardComponent: React.FC<VenueCardProps> = ({ venue, onFavoriteToggle,
       primaryMetaLine={primaryMeta}
     >
       <div className="text-sm text-muted-foreground space-y-1.5 py-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center cursor-default">
-              <Users className="mr-1.5 h-3.5 w-3.5" />
-              <span>{venue.capacity}</span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent><p>Capacity</p></TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center cursor-default">
-              <ThumbsUp className="mr-1.5 h-3.5 w-3.5" />
-              <span>{venue.fanScore ? venue.fanScore.toFixed(1) : 'N/A'}/5.0</span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent><p>Fan Score</p></TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center flex-wrap gap-1 cursor-default">
-              <Tags className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
-              {(venue.djNeeds || []).slice(0, 3).map(genre => (
-                <Link key={genre} href={`/genres/${encodeURIComponent(genre)}`} passHref legacyBehavior>
-                  <Badge variant="outline" className="text-xs hover:bg-accent cursor-pointer">{genre}</Badge>
-                </Link>
-              ))}
-              {(venue.djNeeds || []).length > 3 && <Badge variant="outline" className="text-xs">...</Badge>}
-            </div>
-          </TooltipTrigger>
-          <TooltipContent><p>Genres Needed</p></TooltipContent>
-        </Tooltip>
+        <MetadataItem
+          icon={Users}
+          label="Capacity"
+          value={venue.capacity}
+          tooltipContent={<p>Capacity: {venue.capacity}</p>}
+          className="cursor-default" // Original had no specific text color, default from text-muted-foreground
+        />
+        <MetadataItem
+          icon={ThumbsUp}
+          label="Fan Score"
+          value={`${venue.fanScore ? venue.fanScore.toFixed(1) : 'N/A'}/5.0`}
+          tooltipContent={<p>Fan Score: {venue.fanScore ? venue.fanScore.toFixed(1) : 'N/A'}/5.0</p>}
+          className="cursor-default" // Original had no specific text color
+        />
+        <EntityTags
+          tags={venue.djNeeds || []}
+          icon={Tags}
+          tooltipLabel="Genres Needed"
+          tagLinkPrefix="/genres/"
+          visibleTagCount={3}
+          badgeVariant="outline"
+          // EntityTags handles icon margin, badge text size (via default Badge size), and hover effects.
+          // The 'hover:bg-accent' for outline badges is a specific behavior for this variant.
+          // EntityTags's default linked badge hover is 'hover:bg-secondary/80'.
+          // If 'hover:bg-accent' is critical for 'outline' variant, EntityTags might need enhancement
+          // or a specific className passed to EntityTags to target its badges.
+          // For now, we rely on EntityTags default hover or what its Badge component provides for 'outline'.
+        />
       </div>
     </BaseDiscoveryCard>
   );

--- a/src/components/shared/entity-tags.tsx
+++ b/src/components/shared/entity-tags.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Link from 'next/link';
+import { Badge, type BadgeProps } from '@/components/ui/badge'; // Assuming BadgeProps might be useful for variant
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface EntityTagsProps {
+  tags: string[];
+  icon?: LucideIcon; // React.ElementType can be broader, LucideIcon is more specific if that's the intent
+  tooltipLabel: string;
+  tagLinkPrefix?: string;
+  visibleTagCount?: number;
+  badgeVariant?: BadgeProps['variant']; // Use variant type from BadgeProps
+  className?: string;
+}
+
+const EntityTags: React.FC<EntityTagsProps> = ({
+  tags,
+  icon: Icon,
+  tooltipLabel,
+  tagLinkPrefix,
+  visibleTagCount = 3,
+  badgeVariant = 'secondary',
+  className,
+}) => {
+  if (!tags || tags.length === 0) {
+    return null; // Don't render anything if there are no tags
+  }
+
+  const displayedTags = tags.slice(0, visibleTagCount);
+  const hasMoreTags = tags.length > visibleTagCount;
+
+  const renderTagBadge = (tag: string, isEllipsis = false) => {
+    const badgeContent = <Badge variant={badgeVariant} className={cn(!isEllipsis && tagLinkPrefix && "hover:bg-secondary/80 cursor-pointer", isEllipsis && "cursor-default")}>{isEllipsis ? '...' : tag}</Badge>;
+
+    if (isEllipsis || !tagLinkPrefix) {
+      return badgeContent;
+    }
+
+    return (
+      <Link key={tag} href={`${tagLinkPrefix}${encodeURIComponent(tag)}`} passHref legacyBehavior>
+        {badgeContent}
+      </Link>
+    );
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className={cn("flex items-center flex-wrap gap-1 cursor-default", className)}>
+            {Icon && <Icon className="mr-1 h-3.5 w-3.5 text-muted-foreground" />}
+            {displayedTags.map((tag) => renderTagBadge(tag))}
+            {hasMoreTags && renderTagBadge('...', true)}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{tooltipLabel}</p>
+          {/* Future enhancement: list all tags here if needed */}
+          {/* <p>{tags.join(', ')}</p> */}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default EntityTags;

--- a/src/components/shared/item-grid.tsx
+++ b/src/components/shared/item-grid.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import CardSkeleton from '@/components/shared/card-skeleton'; // Default skeleton
+
+export type CardSize = 'small' | 'medium' | 'large';
+
+export interface ItemGridProps<T> {
+  isLoading: boolean;
+  items: T[];
+  renderItem: (item: T, index: number) => React.ReactNode;
+  cardSize: CardSize;
+  pageLimit?: number;
+  noResultsMessage?: React.ReactNode;
+  getGridColsClass: (size: CardSize) => string;
+  skeletonComponent?: React.ElementType;
+  className?: string;
+  itemClassName?: string; // Added as per requirements, used on the direct wrapper of rendered item
+}
+
+const DEFAULT_PAGE_LIMIT = 8;
+
+function ItemGrid<T>({
+  isLoading,
+  items,
+  renderItem,
+  cardSize,
+  pageLimit = DEFAULT_PAGE_LIMIT,
+  noResultsMessage = <p>No results found.</p>,
+  getGridColsClass,
+  skeletonComponent: SkeletonComponent = CardSkeleton,
+  className,
+  itemClassName,
+}: ItemGridProps<T>) {
+  const gridColsClass = getGridColsClass(cardSize);
+
+  // Case 1: Loading state (and no items yet to display, or items are from a previous load)
+  if (isLoading && items.length === 0) {
+    return (
+      <div className={cn("grid gap-4 md:gap-6", gridColsClass, className)}>
+        {Array.from({ length: pageLimit }).map((_, index) => (
+          <div key={`skeleton-${index}`} className={cn(itemClassName)}>
+            <SkeletonComponent />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // Case 2: No results found (and not loading)
+  if (!isLoading && items.length === 0) {
+    return (
+      <div className={cn("flex justify-center items-center h-40", className)}>
+        {noResultsMessage}
+      </div>
+    );
+  }
+
+  // Case 3: Items to display
+  // We render items even if isLoading is true, assuming items might be from a previous page/cache
+  // and will be replaced once new data loads. The loading indicator should be separate.
+  if (items.length > 0) {
+    return (
+      <div
+        className={cn(
+          "grid gap-4 md:gap-6",
+          gridColsClass,
+          "animate-slide-up-fade-in", // Apply animation when items are present
+          className
+        )}
+      >
+        {items.map((item, index) => (
+          <div key={index} className={cn(itemClassName)}> {/* Consider using item.id if available for key */}
+            {renderItem(item, index)}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return null; // Should not be reached if logic is correct
+}
+
+export default ItemGrid;

--- a/src/components/shared/metadata-item.tsx
+++ b/src/components/shared/metadata-item.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Link from 'next/link';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { LucideIcon } from 'lucide-react';
+
+interface MetadataItemProps {
+  icon?: LucideIcon;
+  label: string;
+  value: React.ReactNode;
+  href?: string;
+  tooltipContent?: React.ReactNode;
+  className?: string;
+}
+
+const MetadataItem: React.FC<MetadataItemProps> = ({
+  icon: Icon,
+  label,
+  value,
+  href,
+  tooltipContent,
+  className,
+}) => {
+  const content = (
+    <>
+      {Icon && <Icon className="mr-1 h-4 w-4" />}
+      {value}
+    </>
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className={`flex items-center text-sm text-muted-foreground ${className || ''}`}>
+            {href ? (
+              <Link href={href} className="flex items-center hover:underline">
+                {content}
+              </Link>
+            ) : (
+              <div className="flex items-center">{content}</div>
+            )}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          {tooltipContent || label}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default MetadataItem;


### PR DESCRIPTION
This commit introduces several new shared components and refactors existing UI to use them, reducing code duplication and improving maintainability.

Key changes:

1.  **New Components:**
    *   `MetadataItem` (`src/components/shared/metadata-item.tsx`): For displaying individual pieces of metadata with an icon, value (optionally linked), and tooltip.
    *   `EntityTags` (`src/components/shared/entity-tags.tsx`): For displaying a list of tags (e.g., genres) with an icon, linking, truncation, and tooltip.
    *   `ItemGrid` (`src/components/shared/item-grid.tsx`): For rendering a grid of items, handling loading skeletons, "no results" messages, and responsive column layouts.

2.  **Card Refactoring:**
    *   `DJCard`, `EventCard`, `VenueCard`, and `RecordingCard` now use `MetadataItem` for consistent display of their textual metadata.
    *   `DJCard`, `EventCard`, and `VenueCard` now use `EntityTags` for displaying genres or similar tag-based information.

3.  **Discovery Page Refactoring:**
    *   `ArtistDiscoveryPage` (`src/app/djs/page.tsx`) and `EventDiscoveryPage` (`src/app/events/page.tsx`) now use `ItemGrid` to manage the display of their respective cards, skeletons, and "no results" views.

These changes address the issue of repeated code by promoting reusability and centralizing common UI logic. Next, I plan to create a `DiscoveryPageLayout` component to further abstract the overall structure of discovery pages.