### PR TITLE
feat: Display loading indicator on navbar clicks

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -46,6 +46,7 @@ import { useUserPreferencesStore } from '@/stores/userPreferencesStore';
 import FocusedSearchOverlay from "@/components/shared/focused-search-overlay";
 import ShortcutGuideDialog from "@/components/shared/shortcut-guide-dialog";
 import CalendarQuickViewDialog from "@/components/shared/CalendarQuickViewDialog";
+import CompactLoadingIndicator from "@/components/shared/CompactLoadingIndicator";
 
 // Lazy load tool window components
 const DevTools = React.lazy(() => import("@/components/dev/dev-tools"));
@@ -102,6 +103,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
   const [mounted, setMounted] = useState(false);
   const [isShortcutGuideOpen, setIsShortcutGuideOpen] = useState(false);
+  const [isPageLoading, setIsPageLoading] = React.useState(false);
 
   const handleCityChange = useCallback((city: string) => {
     setCurrentCity(city);
@@ -142,6 +144,9 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
     }
   }, [mounted, authStoreIsAuthenticated, nextPathname, router]);
 
+  useEffect(() => {
+    setIsPageLoading(false);
+  }, [nextPathname, setIsPageLoading]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -211,7 +216,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                     <AppNameAndLogo />
                     </SidebarHeader>
                     <SidebarContent className="p-2 flex-grow">
-                    <SidebarNav />
+                    <SidebarNav setIsPageLoading={setIsPageLoading} />
                     </SidebarContent>
                     <SidebarFooter className="p-2 border-t border-sidebar-border">
                        <SidebarNav.UserAccountNav currentUserRole={currentUserRole} onLogout={() => authStoreLogout()} />
@@ -367,6 +372,11 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             {mounted && <CalendarQuickViewDialog />} 
             <ShortcutGuideDialog isOpen={isShortcutGuideOpen} onOpenChange={setIsShortcutGuideOpen} />
             <Toaster />
+            {isPageLoading && (
+              <div className="fixed inset-0 z-[200] flex items-center justify-center bg-background/80 backdrop-blur-sm">
+                <CompactLoadingIndicator message="Loading page..." />
+              </div>
+            )}
         </div>
     </TooltipProvider>
   );

--- a/src/components/layout/sidebar-nav.tsx
+++ b/src/components/layout/sidebar-nav.tsx
@@ -29,7 +29,9 @@ import {
 import { useAuthStore } from "@/stores/authStore";
 import { useUserPreferencesStore } from "@/stores/userPreferencesStore"; // Import user preferences store
 
-interface SidebarNavProps extends React.HTMLAttributes<HTMLElement> {}
+interface SidebarNavProps extends React.HTMLAttributes<HTMLElement> {
+  setIsPageLoading: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
 interface UserAccountNavProps {
   currentUserRole: UserRole;
@@ -91,7 +93,7 @@ const UserAccountNavComponent: React.FC<UserAccountNavProps> = ({ currentUserRol
 };
 SidebarNav.UserAccountNav = UserAccountNavComponent;
 
-export function SidebarNav({ className, ...props }: SidebarNavProps) {
+export function SidebarNav({ className, setIsPageLoading, ...props }: SidebarNavProps) {
   const pathname = usePathname();
   const { state: sidebarCurrentState, isMobile } = useSidebar();
   const { currentUserRole } = useAuthStore();
@@ -211,6 +213,7 @@ export function SidebarNav({ className, ...props }: SidebarNavProps) {
             )}
             isActive={item.exactMatch ? pathname === item.href : pathname.startsWith(item.href)}
             tooltip={item.description || item.title}
+            onClick={() => setIsPageLoading(true)}
           >
             {!isPopover && item.icon && <item.icon className={cn("mr-2 flex-shrink-0", isSubItem ? "h-3.5 w-3.5" : "h-4 w-4")} />}
             {(sidebarCurrentState === 'expanded' || isMobile || isPopover) && <span className="truncate">{item.title}</span>}


### PR DESCRIPTION
I've implemented a loading indicator that appears when you click on a navigation item in the sidebar.

Key changes:
- I added an `isPageLoading` state to `AppLayout.tsx` to control the visibility of the loading indicator.
- The `setIsPageLoading` function is passed as a prop to `SidebarNav.tsx`.
- `SidebarNav.tsx` now calls `setIsPageLoading(true)` when a navigation item is clicked.
- `AppLayout.tsx` conditionally renders the `CompactLoadingIndicator` component as an overlay when `isPageLoading` is true.
- A `useEffect` hook in `AppLayout.tsx` monitors route changes via `usePathname` and sets `isPageLoading` to `false` once navigation is complete.

This provides immediate visual feedback to you during page transitions initiated from the sidebar.