### PR TITLE
feat: Implement SpinKit JSON for data export and import

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -166,3 +166,22 @@ export type RecordingSortOption = "title_asc" | "title_desc" | "artist_asc" | "a
 
 // Card Size Type
 export type CardSize = "small" | "medium" | "large";
+
+// Interfaces for SpinKit Export
+export interface SpinKitExport {
+  driver: "notion" | "mongodb";
+  exportDate: string; // ISO date
+  connectionName: string;
+  payload: SpinKitPayloadTable[];
+}
+
+export interface SpinKitPayloadTable {
+  name: string; // collection/database name
+  id: string; // collection/database ID
+  records: SpinKitRecord[];
+}
+
+export interface SpinKitRecord {
+  id: string; // original record ID
+  properties: object; // the actual data, can be `any` or a generic type for now
+}


### PR DESCRIPTION
Introduces a standardized SpinKit JSON format for data exports.

Key changes:
- Defined `SpinKitExport`, `SpinKitPayloadTable`, and `SpinKitRecord` TypeScript interfaces in `src/types.ts` to serve as the canonical representation of the export format.
- Refactored the data export functionality in `src/components/admin/data-tools/export-data-section.tsx`:
    - Exports from Notion and MongoDB/LocalJSON now adhere to the SpinKit JSON structure.
    - The `driver` field is correctly set to "notion" or "mongodb".
    - Notion data includes Page ID as `id` and page properties under `properties`. Image URLs are correctly extracted.
    - MongoDB/LocalJSON data includes document ID as `id` and the document itself under `properties`.
- Updated the Data Import Wizard (`src/components/admin/data-tools/import-data-section.tsx` and `src/components/admin/data-tools/import-wizard/import-wizard-utils.tsx`):
    - The wizard now correctly identifies SpinKit formatted files (both Notion and MongoDB drivers).
    - Column detection for SpinKit MongoDB files now correctly lists the top-level `id` and fields within the `properties` object.
    - Utility functions `getDisplayValue` and `transformSingleRecord` were updated to accurately read data from the SpinKit structure (`record.id` and `record.properties`) for preview and transformation during import.
    - Added 'mongodb_spinkit' to `StagedDataFormat` driver types.

This ensures that data exports are consistent and that the import wizard can correctly process these standardized files, improving data interoperability within the application.